### PR TITLE
Fix button text CSS variable

### DIFF
--- a/src/components/Settings/SetupScreen.tsx
+++ b/src/components/Settings/SetupScreen.tsx
@@ -201,7 +201,7 @@ export default function SetupScreen({ initial, onSave, onCancel }: Props) {
                 onClick={() => setDifficulty(level as Settings['difficulty'])}
                 className={`flex-1 text-sm py-2 rounded-lg ${
                   difficulty === level
-                    ? 'bg-[var(--accent-color)] text-[var(--bt-text-text)] shadow'
+                    ? 'bg-[var(--accent-color)] text-[var(--bt-text-color)] shadow'
                     : 'bg-transparent text-[var(--text-color)] hover:bg-[var(--hover-bg)]'
                 }`}
               >

--- a/src/index.css
+++ b/src/index.css
@@ -13,7 +13,7 @@
   --title-color:    #1f2937; /* H1/H2 titles */
   --text-color:     #374151; /* paragraph and answers */
   --accent-color:   #3b82f6; /* primary buttons and highlights */
-  --bt-text-text:   #ffffff; /* primary text color on buttons */
+  --bt-text-color:  #ffffff; /* primary text color on buttons */
   --second-bg:      #9ca3af; /* secundary buttons or non-selected buttons */
   --second-text:    #1f2937; /* secundary text color on buttons */
   --hover-color:    #2563eb; /* hover state for interactive elements */


### PR DESCRIPTION
## Summary
- rename CSS variable to `--bt-text-color`
- update difficulty button style to use the renamed variable

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f635d04a48322b798408b448a079e