### PR TITLE
Reset loading/error when settings change

### DIFF
--- a/src/hooks/useQuestions.ts
+++ b/src/hooks/useQuestions.ts
@@ -19,10 +19,14 @@ export default function useQuestions(
   const [error, setError]         = useState(false)
 
   useEffect(() => {
+    // Whenever the parameters change, reset loading and error state
+    setLoading(true)
+    setError(false)
+
     // 1. Sanitize inputs
     const safeAmount = Math.min(50, Math.max(1, amount))
     const allowedDifficulties = ['any', 'easy', 'medium', 'hard'] as const
-    const safeDifficulty: typeof difficulty = 
+    const safeDifficulty: typeof difficulty =
       allowedDifficulties.includes(difficulty) ? difficulty : 'any'
     const safeCategory = Number.isInteger(category) && category > 0
       ? category


### PR DESCRIPTION
## Summary
- trigger loading and clear errors whenever questions are refetched

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f6371becc83228c3ceba9ff4c8137