### PR TITLE
Add menu backdrop and escape key handler

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import App from './App'
+
+describe('App menu behavior', () => {
+  it('closes menu when Escape key pressed', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    act(() => {
+      createRoot(container).render(<App />)
+    })
+
+    const toggle = container.querySelector('nav button')!
+    act(() => {
+      toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(container.textContent).toContain('Gameplay Options')
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+
+    expect(container.textContent).not.toContain('Gameplay Options')
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,17 @@ export default function App() {
     setStage(prev => (prev === 'menu' ? 'start' : 'menu'))
   }
 
+  // Close menu when Escape key is pressed
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && stage === 'menu') {
+        toggleMenu()
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [stage])
+
   /** Apply a new theme and close menu */
   const handleThemeSelect = (theme: Settings['theme']) => {
     setSettings(prev => ({ ...prev, theme }))
@@ -104,6 +115,11 @@ export default function App() {
       {/* Menu overlay: dimmed backdrop + responsive drawer panel */}
       {stage === 'menu' && (
         <>
+          <div
+            className="menu-backdrop"
+            onClick={toggleMenu}
+            data-testid="menu-backdrop"
+          />
           {/* Drawer panel: full-width at top on mobile; side on desktop */}
           <div className="inset-x-0 top-0 md:inset-y-0 md:right-0 z-20">
             <MenuScreen

--- a/src/index.css
+++ b/src/index.css
@@ -145,6 +145,9 @@ body {
            transition-colors duration-500
            bg-[var(--bg-color)];
   }
+  .menu-backdrop {
+    @apply fixed inset-0 z-10 bg-black/40 backdrop-blur-sm;
+  }
   /* Width for Usable Elements */
   .main-width {
     @apply w-[760px] max-w-[90%];


### PR DESCRIPTION
## Summary
- add `menu-backdrop` styling
- close the menu on Escape key press
- dim the viewport with a backdrop that closes the menu on click
- test Escape key closing behavior

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f65ce81d08322a89b9faec72bb398