### PR TITLE
Add persistent settings via localStorage

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -25,6 +25,7 @@ An interactive quiz application built with React, TypeScript, Vite, and Tailwind
 * **Responsive Design**: Mobile‑first drawer at top and desktop sidebar on the right, with backdrop blur.
 * **Type Safety**: Full TypeScript support for API responses and settings.
 * **Lightning Fast**: Powered by Vite for instant HMR and Vitest for unit testing.
+* **Persistent Settings**: Theme and gameplay options are saved to `localStorage`.
 
 ---
 
@@ -176,7 +177,6 @@ npm run deploy
 * Timer per question
 * Progress bar animations
 * Background animations
-* LocalStorage persistence
 * Enhanced accessibility (ARIA)
 * Score ranking
 * More themes & UI polish

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,11 +15,22 @@ import type { OpenTDBQuestion, Settings } from './types'
  */
 export default function App() {
   // 1. Store user settings: theme, category, amount, difficulty
-  const [settings, setSettings] = useState<Settings>({
+  const defaultSettings: Settings = {
     theme: 'default',
     category: 0,
     amount: 10,
     difficulty: 'any',
+  }
+  const [settings, setSettings] = useState<Settings>(() => {
+    const saved = localStorage.getItem('settings')
+    if (saved) {
+      try {
+        return { ...defaultSettings, ...JSON.parse(saved) }
+      } catch {
+        // fall through to defaults
+      }
+    }
+    return defaultSettings
   })
 
   // 2. Fetch questions whenever gameplay settings change
@@ -60,6 +71,11 @@ export default function App() {
 
   /** Start the quiz */
   const handleStart = () => setStage('quiz')
+
+  /** Persist settings whenever they change */
+  useEffect(() => {
+    localStorage.setItem('settings', JSON.stringify(settings))
+  }, [settings])
 
   /** Record a user's answer, ignoring duplicates */
   const handleAnswer = (id: string, correct: boolean) => {


### PR DESCRIPTION
## Summary
- load saved settings from localStorage
- store settings back to localStorage on change
- document that settings persist between sessions

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f65ec6c148322a449514294329e9e