### PR TITLE
Fix menu panel class name

### DIFF
--- a/src/components/Layouts/MenuScreen.tsx
+++ b/src/components/Layouts/MenuScreen.tsx
@@ -32,7 +32,7 @@ export default function MenuScreen({
   const [tab, setTab] = useState<'settings' | 'theme'>('settings')
 
   return (
-    <div className="menu-painel md:flex-row">
+    <div className="menu-panel md:flex-row">
       {/* MenuBar: row on mobile, column on desktop */}
       <div className="flex md:flex-col mb-4
     space-x-4 space-y-0 md:space-x-0 md:space-y-4 md:pt-16 md:pr-4 md:border-r border-[var(--border-color)]">

--- a/src/index.css
+++ b/src/index.css
@@ -165,10 +165,10 @@ body {
            border border-[var(--border-color)] 
            rounded-lg shadow-md;
   }
-  .menu-painel {
+  .menu-panel {
     @apply relative text-center p-6 m-auto main-width min-h-[396px]
            bg-[var(--content-bg)] flex flex-col
-           border border-[var(--border-color)] 
+           border border-[var(--border-color)]
            rounded-lg shadow-md;
   }
 


### PR DESCRIPTION
## Summary
- rename `.menu-painel` CSS class to `.menu-panel`
- update `MenuScreen` to use the new class name

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686094d0ebe8832283ac1363c91a40be