### PR TITLE
Refactor setup options

### DIFF
--- a/src/components/Settings/AmountSlider.tsx
+++ b/src/components/Settings/AmountSlider.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+interface Props {
+  value: number
+  onChange: (val: number) => void
+  error?: string
+}
+
+export default function AmountSlider({ value, onChange, error }: Props) {
+  return (
+    <div>
+      <label className="block mb-1 text-sm text-[var(--text-color)]">
+        Number of Questions: <span>{value}</span>
+      </label>
+      <input
+        type="range"
+        min={1}
+        max={50}
+        value={value}
+        onChange={e => onChange(+e.target.value)}
+        className="w-full accent-[var(--accent-color)]"
+      />
+      {error && <p className="text-red-600 text-xs mt-1">{error}</p>}
+    </div>
+  )
+}

--- a/src/components/Settings/CategorySelector.tsx
+++ b/src/components/Settings/CategorySelector.tsx
@@ -1,0 +1,83 @@
+import React, { useState, Fragment } from 'react'
+import { Combobox, Transition } from '@headlessui/react'
+import type { Category } from '../../types'
+
+interface Props {
+  categories: Category[]
+  value: number
+  onChange: (value: number) => void
+  error?: string
+}
+
+export default function CategorySelector({
+  categories,
+  value,
+  onChange,
+  error,
+}: Props) {
+  const [query, setQuery] = useState('')
+
+  const filtered =
+    query === ''
+      ? categories
+      : categories.filter(cat =>
+          cat.name.toLowerCase().includes(query.toLowerCase()),
+        )
+
+  return (
+    <div>
+      <label className="block mb-1 text-sm text-[var(--text-color)]">
+        Category
+      </label>
+      <Combobox<number>
+        value={value}
+        onChange={val => {
+          if (val !== null) onChange(val)
+        }}
+      >
+        <div className="relative">
+          <Combobox.Input
+            className="w-full border border-[var(--border-color)] p-2 rounded bg-transparent text-[var(--text-color)] placeholder:text-gray-400"
+            displayValue={cat => categories.find(c => c.id === cat)?.name || ''}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Any Category"
+          />
+          <Transition
+            as={Fragment}
+            leave="transition ease-in duration-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Combobox.Options className="absolute z-20 mt-1 w-full bg-[var(--content-bg)] border border-[var(--border-color)] rounded max-h-40 overflow-auto">
+              <Combobox.Option
+                key={0}
+                value={0}
+                className={({ active, selected }) =>
+                  `cursor-pointer px-3 py-2 text-sm ${
+                    active ? 'bg-blue-100' : ''
+                  } ${selected ? 'font-semibold' : ''}`
+                }
+              >
+                Any Category
+              </Combobox.Option>
+              {filtered.map(cat => (
+                <Combobox.Option
+                  key={cat.id}
+                  value={cat.id}
+                  className={({ active, selected }) =>
+                    `cursor-pointer px-3 py-2 text-sm ${
+                      active ? 'bg-blue-100' : ''
+                    } ${selected ? 'font-semibold' : ''}`
+                  }
+                >
+                  {cat.name}
+                </Combobox.Option>
+              ))}
+            </Combobox.Options>
+          </Transition>
+        </div>
+      </Combobox>
+      {error && <p className="text-red-600 text-xs mt-1">{error}</p>}
+    </div>
+  )
+}

--- a/src/components/Settings/DifficultySelector.tsx
+++ b/src/components/Settings/DifficultySelector.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import type { Settings } from '../../types'
+
+interface Props {
+  value: Settings['difficulty']
+  onChange: (val: Settings['difficulty']) => void
+  error?: string
+}
+
+export default function DifficultySelector({ value, onChange, error }: Props) {
+  const levels: Settings['difficulty'][] = ['any', 'easy', 'medium', 'hard']
+
+  return (
+    <div>
+      <label className="block mb-1 text-sm text-[var(--text-color)]">
+        Difficulty
+      </label>
+      <div className="flex space-x-1 bg-[var(--border-color)] p-1 rounded-lg">
+        {levels.map(level => (
+          <button
+            key={level}
+            type="button"
+            onClick={() => onChange(level)}
+            className={`flex-1 text-sm py-2 rounded-lg ${
+              value === level
+                ? 'bg-[var(--accent-color)] text-[var(--bt-text-color)] shadow'
+                : 'bg-transparent text-[var(--text-color)] hover:bg-[var(--hover-bg)]'
+            }`}
+          >
+            {level === 'any' ? 'Any' : level.charAt(0).toUpperCase() + level.slice(1)}
+          </button>
+        ))}
+      </div>
+      {error && <p className="text-red-600 text-xs mt-1">{error}</p>}
+    </div>
+  )
+}

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react'
+import type { Category } from '../types'
+
+export default function useCategories() {
+  const [categories, setCategories] = useState<Category[]>([])
+
+  useEffect(() => {
+    fetch('https://opentdb.com/api_category.php')
+      .then(res => res.json())
+      .then(data => setCategories(data.trivia_categories))
+      .catch(() => {
+        // If fetch fails, categories stay empty (user sees only "Any Category")
+      })
+  }, [])
+
+  return { categories }
+}


### PR DESCRIPTION
## Summary
- add `useCategories` hook to fetch available categories
- extract UI pieces into `CategorySelector`, `AmountSlider` and `DifficultySelector`
- simplify `SetupScreen` to use new components and hook

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68609669191c8322aa927d7a8242a137