### PR TITLE
Fix color scheme comment typo

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,7 @@
 
 /* -------------------------------
   Theme variables Start
-  Color Schema
+  Color Scheme
    ------------------------------- */
 /* Default theme (fallback) */
 :root {


### PR DESCRIPTION
## Summary
- correct "Color Schema" to "Color Scheme" in `src/index.css`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af695df448322b927efaaf09c7209