### PR TITLE
Fix incorrect error color style

### DIFF
--- a/src/components/Settings/ElasticSlider.tsx
+++ b/src/components/Settings/ElasticSlider.tsx
@@ -38,7 +38,7 @@ const ElasticSlider: React.FC<ElasticSliderProps> = ({
         leftIcon={leftIcon}
         rightIcon={rightIcon}
       />
-      {error && <p className="text-[var(-fb-incorrect)] text-xs mt-1">{error}</p>}
+      {error && <p className="text-[var(--fb-incorrect)] text-xs mt-1">{error}</p>}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- correct the error text color in `ElasticSlider`

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af699d3e483229602bbfbfac41813