### PR TITLE
Update scripts section in README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -54,14 +54,12 @@ Select themes in the menu drawer and see live previews instantly.
 - **Testing (boilerplate):** Vitest + Testing Library
 - **Deployment Tools:** npm scripts, `gh-pages`
 
-
 ---
 
 ## 📁 Project Structure
 
 - `/src`: Source code to be analyzed and maintained by AI agents
   - `/components`: React components that should follow the guidelines in this document
-
 
 ---
 
@@ -115,11 +113,10 @@ Select themes in the menu drawer and see live previews instantly.
 
 - `npm run dev` — start development server
 - `npm run build` — compile for production
-- `npm run start` — run production build locally
+- `npm run preview` — preview production build locally
 - `npm run lint` — run ESLint
 - `npm run format` — run Prettier
 - `npm run test` — run unit tests
-- `npm run test:watch` — run tests in watch mode
 
 _Add these lines to `package.json` if using `gh-pages`:_
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import App from './App';
@@ -10,17 +10,24 @@ let root: Root;
 afterEach(() => {
   root.unmount();
   container.remove();
+  vi.restoreAllMocks();
 });
 
 describe('App menu behavior', () => {
-  it('closes menu when Escape key pressed', () => {
+  it('closes menu when Escape key pressed', async () => {
     container = document.createElement('div');
     document.body.appendChild(container);
 
-    act(() => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      json: () => Promise.resolve({ results: [] }),
+    } as Response);
+
+    await act(async () => {
       root = createRoot(container);
       root.render(<App />);
     });
+
+    await act(async () => {});
 
     const toggle = container.querySelector('nav button')!;
     act(() => {


### PR DESCRIPTION
## Summary
- correct npm script list in the README
- mock fetch in `App` test so vitest runs without errors

## Testing
- `npm run format`
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_686c3ff7e8c08322bb5d2f5f102f480e