### PR TITLE
Remove react helmet from docs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -50,10 +50,8 @@ Select themes in the menu drawer and see live previews instantly.
 - **Styling:** Tailwind CSS (v3+) with `@apply`, custom keyframes, JIT
 - **Animations:** Framer Motion, CSS keyframes
 - **Icons:** lucide‑react
-- **SEO:** react‑helmet‑async
 - **Testing (boilerplate):** Vitest + Testing Library
 - **Deployment Tools:** npm scripts, `gh-pages`
-
 
 ---
 
@@ -61,7 +59,6 @@ Select themes in the menu drawer and see live previews instantly.
 
 - `/src`: Source code to be analyzed and maintained by AI agents
   - `/components`: React components that should follow the guidelines in this document
-
 
 ---
 


### PR DESCRIPTION
## Summary
- remove the `react-helmet-async` entry from the tech stack list in README

## Testing
- `npm run format`
- `npm run lint`
- `npm run test` *(fails: Cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_686c3ff8f32c832291b67de1474627cc