### PR TITLE
Fix bullet style in AGENTS guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ This `Agents.md` file provides comprehensive guidance for any AI agents working 
 - Use functional components with hooks.
 - Keep components small and focused.
 - Always define prop types properly.
-- Use PascalCase for component filenames.~
+- Use PascalCase for component filenames.
 
 ## CSS/Styling Standards
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import App from './App';
+
+// Avoid network calls by mocking the questions hook
+vi.mock('./hooks/useQuestions', () => ({
+  default: () => ({ questions: [], loading: false, error: false }),
+}));
 
 let container: HTMLDivElement;
 let root: Root;


### PR DESCRIPTION
## Summary
- remove stray tilde from the React guidelines
- mock `useQuestions` in `App.test.tsx` to avoid network calls

## Testing
- `npm run lint`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_686c3ffa48ec83228f5813175d20f3a9