### PR TITLE
Update README to remove gh-pages snippet

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -121,15 +121,6 @@ Select themes in the menu drawer and see live previews instantly.
 - `npm run test` — run unit tests
 - `npm run test:watch` — run tests in watch mode
 
-_Add these lines to `package.json` if using `gh-pages`:_
-
-```json
-"scripts": {
-  "predeploy": "npm run build",
-  "deploy": "gh-pages -d dist"
-}
-```
-
 ---
 
 ## ☁️ Deployment


### PR DESCRIPTION
## Summary
- remove instructions for adding gh-pages deploy scripts
- restore original spacing

## Testing
- `npm run format`
- `npm run lint`
- `npm run test` *(fails: Cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_686c3fff4b148322bd865e077c4e8f0c