### PR TITLE
Fix afterEach cleanup safety

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -9,12 +9,18 @@ vi.mock('./hooks/useQuestions', () => ({
   default: () => ({ questions: [], loading: false, error: false }),
 }));
 
-let container: HTMLDivElement;
-let root: Root;
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
 
 afterEach(() => {
-  root.unmount();
-  container.remove();
+  if (root) {
+    root.unmount();
+    root = null;
+  }
+  if (container) {
+    container.remove();
+    container = null;
+  }
 });
 
 describe('App menu behavior', () => {


### PR DESCRIPTION
## Summary
- ensure tests cleanup only when mounted
- guard container removal

## Testing
- `npm run format` *(fails: SyntaxError in src/App.test.tsx)*
- `npm run lint` *(fails: Parsing error in src/App.test.tsx)*
- `npm test` *(fails: Unexpected end of file in src/App.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_686c46ef1a3c832292eca79fb8851f84